### PR TITLE
fix: fix words in mobile nav

### DIFF
--- a/client/src/components/HeaderMenu.js
+++ b/client/src/components/HeaderMenu.js
@@ -54,10 +54,12 @@ export default function FullScreenDialog(props) {
 
         <div className="btn-area">
           <button
-            className={`${'btn-mobile-menu'} ${props.currentLocation == '/' && 'active-mobile'}`}
+            className={`${'btn-mobile-menu'} ${props.currentLocation == '/' && 'active-mobile'} ${
+              props.currentLocation == '/dashboard' && 'active-mobile'
+            }`}
             onClick={handleMenuClose}
           >
-            <Link to="/">Home</Link>
+            <Link to="/">{props.currentUser ? 'Dashboard' : 'Home'}</Link>
           </button>
         </div>
         {props.currentUser && (


### PR DESCRIPTION
change words 'home' to 'dashboard' in mobile nav